### PR TITLE
Fix link import in Footer component

### DIFF
--- a/components/navigation/Footer/Footer.tsx
+++ b/components/navigation/Footer/Footer.tsx
@@ -1,7 +1,7 @@
 import { Container } from '@/components/layout/Container/Container';
 import { Row } from '@/components/layout/Row/Row';
 import { Button } from '@/components/ui/button';
-import Link from 'next/dist/client/link';
+import Link from 'next/link';
 
 const year = new Date().getFullYear();
 const navigationLinks = {


### PR DESCRIPTION
## Summary
- correct Link import path in `Footer`

## Testing
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f528e55508329a3395de6d5193189